### PR TITLE
Allow for queries that don't require a DB to execute

### DIFF
--- a/src/loki/core.clj
+++ b/src/loki/core.clj
@@ -15,8 +15,8 @@
   (->> (athena/exec db (str "show tables in " db))
        (map #(str db "." (:tab_name %)))))
 
-(defn describe [tb]
-  (let [stmt (athena/exec (str "show create table " (name tb)))]
+(defn describe [db tb]
+  (let [stmt (athena/exec db (str "show create table " (name tb)))]
     (apply str (interpose "\n" (map :createtab_stmt stmt)))))
 
 (defn assert!
@@ -44,10 +44,15 @@
   (-> (render query values)
       (sql/sql)))
 
-(defn exec [db query-str]
-  (athena/exec db (format "%s" query-str)))
+(defn exec
+  ([query-str]
+   (athena/exec query-str))
+  ([db query-str]
+   (athena/exec db (format "%s" query-str))))
 
 (defn query
+  ([query-map]
+   (query nil query-map {} {}))
   ([db query-map]
    (query db query-map {} {}))
   ([db query-map values]


### PR DESCRIPTION
Some queries (for example, listing databases), don't require a DB but their queries won't currently execute when no database is passed, this patch handles the case where no database is explicitly provided to an athena query.

Additionally, this correctly passes a database for table description