### PR TITLE
Fix schema command

### DIFF
--- a/src/loki/core.clj
+++ b/src/loki/core.clj
@@ -36,6 +36,7 @@
        (athena/exec (name db))
        (map as-col)
        (remove nil?)
+       (map (fn [[k v & _]] [k v]))
        (into (sorted-map))
        (walk/keywordize-keys)
        (into (sorted-map))))


### PR DESCRIPTION
Currently `schema` throws:

```
                                                  loki.core/schema          core.clj:   39
                                                 clojure.core/into          core.clj: 6815
                                               clojure.core/reduce          core.clj: 6748
                                       clojure.core.protocols/fn/G     protocols.clj:   13
                                         clojure.core.protocols/fn     protocols.clj:   75
                                 clojure.core.protocols/seq-reduce     protocols.clj:   31
                                       clojure.core.protocols/fn/G     protocols.clj:   19
                                         clojure.core.protocols/fn     protocols.clj:  168
                                                 clojure.core/conj          core.clj:   85
                                                               ...
java.lang.IllegalArgumentException: Vector arg to map conj must be a pair
```

This fixes and produces the map of 

```clojure
{:field1 "type"
 :field2 "type"}
```